### PR TITLE
Upgraded for Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,29 +12,32 @@ COPY requirements.txt /opt/app/requirements.txt
 
 # Install packages
 RUN yum update -y
-RUN yum install -y cpio python3-pip yum-utils zip unzip less
+RUN yum install -y cpio yum-utils zip unzip less wget
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN amazon-linux-extras install -y python3.8
 
 # This had --no-cache-dir, tracing through multiple tickets led to a problem in wheel
-RUN pip3 install -r requirements.txt
+RUN pip3.8 install -r requirements.txt
 RUN rm -rf /root/.cache/pip
 
 # Download libraries we need to run in lambda
 WORKDIR /tmp
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update json-c pcre2 libprelude gnutls libtasn1 lib64nettle nettle
+RUN yumdownloader --resolve -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update \
+    json-c pcre2 libprelude gnutls nettle libtool-ltdl
 RUN rpm2cpio clamav-0*.rpm | cpio -idmv
 RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
 RUN rpm2cpio clamav-update*.rpm | cpio -idmv
 RUN rpm2cpio json-c*.rpm | cpio -idmv
 RUN rpm2cpio pcre*.rpm | cpio -idmv
+RUN rpm2cpio libprelude* | cpio -idmv
 RUN rpm2cpio gnutls* | cpio -idmv
 RUN rpm2cpio nettle* | cpio -idmv
-RUN rpm2cpio lib* | cpio -idmv
-RUN rpm2cpio *.rpm | cpio -idmv
-RUN rpm2cpio libtasn1* | cpio -idmv
+RUN rpm2cpio libtool-ltdl* | cpio -idmv
 
 # Copy over the binaries and libraries
 RUN cp /tmp/usr/bin/clamscan /tmp/usr/bin/freshclam /tmp/usr/lib64/* /opt/app/bin/
+RUN find /usr/lib64/* -type f -maxdepth 0 -exec cp {} /opt/app/bin/ \;
+RUN find /usr/lib64/* -type l -maxdepth 0 -exec cp {} /opt/app/bin/ \;
 
 # Fix the freshclam.conf settings
 RUN echo "DatabaseMirror database.clamav.net" > /opt/app/bin/freshclam.conf
@@ -44,7 +47,7 @@ RUN echo "CompressLocalDatabase yes" >> /opt/app/bin/freshclam.conf
 WORKDIR /opt/app
 RUN zip -r9 --exclude="*test*" /opt/app/build/lambda.zip *.py bin
 
-WORKDIR /usr/local/lib/python3.7/site-packages
+WORKDIR /usr/local/lib/python3.8/site-packages
 RUN zip -r9 /opt/app/build/lambda.zip *
 
 WORKDIR /opt/app

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet==3.0.4
 datadog==0.26.0
 decorator==4.3
 idna==2.8
-requests==2.21
+requests==2.27
 simplejson==3.16
-urllib3==1.24.2
+urllib3==1.26.5
 pytz==2019.3


### PR DESCRIPTION
Upgraded for Python 3.8

Fixed Dockerfile for python 3.8 and resolved ClamAV dependency.
Changed script to use environment variables since the ld command is not available.
Compressed files named in Japanese may cause errors. Therefore, use the "ignore" option.